### PR TITLE
Add Mongo-Client wrapper

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,12 +18,12 @@
   revision = "f4dd9f5a6b441265aefc1d44872a6f8c10f42b37"
 
 [[projects]]
-  digest = "1:c4a2528ccbcabf90f9f3c464a5fc9e302d592861bbfd0b7135a7de8a943d0406"
+  digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
   name = "github.com/go-stack/stack"
   packages = ["."]
   pruneopts = "UT"
-  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
-  version = "v1.7.0"
+  revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
+  version = "v1.8.0"
 
 [[projects]]
   branch = "master"
@@ -48,7 +48,15 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:7edc7c7e004c3f79e8001690a25803394a3e2a973100b24329bf2fa324eb1fe5"
+  digest = "1:70e697d67ccaec45e16bac3a32380ebcd9e7e071079c60d0171d42cf1cf9748a"
+  name = "github.com/joho/godotenv"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a79fa1e548e2c689c241d10173efd51e5d689d5b"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:c990d4427f9d6c34549935233b7034bed5460bc4db829f3cdf3392160f35dcaf"
   name = "github.com/mongodb/mongo-go-driver"
   packages = [
     "bson",
@@ -99,11 +107,12 @@
     "mongo/replaceopt",
     "mongo/runcmdopt",
     "mongo/sessionopt",
+    "mongo/transactionopt",
     "mongo/updateopt",
   ]
   pruneopts = "UT"
-  revision = "9b26cbb1a61aaedd6160e99c41fa514b04a1a245"
-  version = "v0.0.11"
+  revision = "b75c1ad5f277465dc7bdcc3d14c5177a89b6a4f9"
+  version = "v0.0.13"
 
 [[projects]]
   digest = "1:42e29deef12327a69123b9cb2cb45fee4af5c12c2a23c6e477338279a052703f"
@@ -154,16 +163,40 @@
   version = "v1.4.1"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:40fdfd6ab85ca32b6935853bbba35935dcb1d796c8135efd85947566c76e662e"
+  name = "github.com/xdg/scram"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "7eeb5667e42c09cb51bf7b7c28aea8c56767da90"
+
+[[projects]]
+  digest = "1:577b99fc55ee19cbf1ffd072808c91ced78cd732bd9d0517bec9b90e532069cb"
+  name = "github.com/xdg/stringprep"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bd625b8dc1e3b0f57412280ccbcc317f0c69d8db"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   digest = "1:f92f6956e4059f6a3efc14924d2dd58ba90da25cc57fe07ae3779ef2f5e0c5f2"
   name = "golang.org/x/crypto"
   packages = ["pbkdf2"]
   pruneopts = "UT"
-  revision = "aabede6cba87e37f413b3e60ebfc214f8eeca1b0"
+  revision = "0709b304e793a5edb4a2c0145f281ecdc20838a4"
 
 [[projects]]
   branch = "master"
-  digest = "1:69c9160034ef8869921ed316499f7e7e94b9e029338bce6dcb63a7ba9e753397"
+  digest = "1:6b508ddf4dafd8889ef647eb30be109c6b8ff73e097ca9b077d4d89ec89ce97e"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -172,7 +205,7 @@
     "html/charset",
   ]
   pruneopts = "UT"
-  revision = "aaf60122140d3fcf75376d319f0554393160eb50"
+  revision = "161cd47e91fd58ac17490ef4d742dc98bb4cf60e"
 
 [[projects]]
   branch = "master"
@@ -184,14 +217,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e3e7f51633f98fce9404940f74dfd65cf306ee173ddf5a8b247c9c830e42b38a"
+  digest = "1:a3e01ee03246312c2e186cc4dde0d639e2c269f430042a57cc1c795ae9902016"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "1a700e749ce29638d0bbcb531cce1094ea096bd3"
+  revision = "8cf3aee429924738c56c34bb819c4ea8273fc434"
 
 [[projects]]
-  digest = "1:aa4d6967a3237f8367b6bf91503964a77183ecf696f1273e8ad3551bb4412b5f"
+  digest = "1:4392fcf42d5cf0e3ff78c96b2acf8223d49e4fdc53eb77c99d2f8dfe4680e006"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -206,11 +239,14 @@
     "encoding/unicode",
     "internal/gen",
     "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
     "internal/utf8internal",
     "language",
     "runes",
     "transform",
     "unicode/cldr",
+    "unicode/norm",
   ]
   pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
@@ -246,11 +282,14 @@
   analyzer-version = 1
   input-imports = [
     "github.com/TerrexTech/go-commonutils/utils",
+    "github.com/joho/godotenv",
     "github.com/mongodb/mongo-go-driver/bson",
     "github.com/mongodb/mongo-go-driver/bson/objectid",
     "github.com/mongodb/mongo-go-driver/mongo",
+    "github.com/mongodb/mongo-go-driver/mongo/findopt",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
+    "github.com/pkg/errors",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/examples/example.go
+++ b/examples/example.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"context"
 	"log"
-	"time"
 
 	"github.com/TerrexTech/go-mongoutils/mongo"
 	"github.com/mongodb/mongo-go-driver/bson"
 	"github.com/mongodb/mongo-go-driver/bson/objectid"
-	mgo "github.com/mongodb/mongo-go-driver/mongo"
 	"github.com/mongodb/mongo-go-driver/mongo/findopt"
 	"github.com/pkg/errors"
 )
@@ -67,17 +64,15 @@ func main() {
 // createCollection demonstrates creating the collection and the associated database.
 func createCollection() (*mongo.Collection, error) {
 	// Would ideally set these config-params as environment vars
-	client, err := mgo.NewClient("mongodb://root:root@localhost:27017")
-	if err != nil {
-		log.Fatalln(err)
+	config := mongo.ClientConfig{
+		Hosts:               []string{"localhost:27017"},
+		Username:            "root",
+		Password:            "root",
+		TimeoutMilliseconds: 3000,
 	}
 
-	ctx, cancel := context.WithTimeout(
-		context.Background(),
-		time.Duration(1)*time.Second,
-	)
-	defer cancel()
-	err = client.Connect(ctx)
+	// ====> MongoDB Client
+	client, err := mongo.NewClient(config)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -1,0 +1,107 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	mgo "github.com/mongodb/mongo-go-driver/mongo"
+	"github.com/pkg/errors"
+)
+
+// ClientConfig represents the configuration for a client.
+type ClientConfig struct {
+	Hosts               []string
+	Username            string
+	Password            string
+	NoDefaultConnect    bool
+	TimeoutMilliseconds uint32
+}
+
+// Client represents a MongoDB client.
+// This wraps the Mongo-Go-Driver client.
+type Client struct {
+	client    *mgo.Client
+	connected bool
+	timeout   uint32
+}
+
+// NewClient creates new client based on the ClientConfig provided.
+func NewClient(config ClientConfig) (*Client, error) {
+	connStr := fmt.Sprintf(
+		"mongodb://%s:%s@%s",
+		config.Username,
+		config.Password,
+		config.Hosts[0],
+	)
+	mgoClient, err := mgo.NewClient(connStr)
+	if err != nil {
+		err = errors.Wrap(err, "Error Creating MongoDB Client")
+		return nil, err
+	}
+	if config.TimeoutMilliseconds == 0 {
+		config.TimeoutMilliseconds = 1000
+	}
+	client := &Client{
+		client:  mgoClient,
+		timeout: config.TimeoutMilliseconds,
+	}
+
+	if config.NoDefaultConnect {
+		client.connected = false
+		return client, err
+	}
+	err = client.Connect()
+	return client, err
+}
+
+// Connect connects the created client to Database. This is a no-op if
+// the client is already connected.
+// This is also run by default unless "NoDefaultConnect" is specified in ClientConfig.
+func (c *Client) Connect() error {
+	if !c.connected {
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			time.Duration(c.timeout)*time.Millisecond,
+		)
+		defer cancel()
+
+		err := c.client.Connect(ctx)
+		if err != nil {
+			err = errors.Wrap(err, "Error Connecting MongoDB Client to Database")
+			return err
+		}
+		c.connected = true
+	}
+	return nil
+}
+
+// Disconnect disconnects the created client from Database. This is a no-op if
+// the client is already disconnected.
+func (c *Client) Disconnect() error {
+	if c.connected {
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			time.Duration(c.timeout)*time.Millisecond,
+		)
+		defer cancel()
+
+		err := c.client.Disconnect(ctx)
+		if err != nil {
+			err = errors.Wrap(err, "Error Disconnecting MongoDB Client from Database")
+			return err
+		}
+		c.connected = false
+	}
+	return nil
+}
+
+// Database returns a handle for a given database.
+func (c *Client) Database(dbName string) *mgo.Database {
+	return c.client.Database(dbName)
+}
+
+// DriverClient returns the wrapped Mongo-Go-Driver client.
+func (c *Client) DriverClient() *mgo.Client {
+	return c.client
+}

--- a/mongo/client_test.go
+++ b/mongo/client_test.go
@@ -1,0 +1,151 @@
+package mongo
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/TerrexTech/go-commonutils/utils"
+	mgo "github.com/mongodb/mongo-go-driver/mongo"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+)
+
+var _ = Describe("MongoClient", func() {
+	Context("new client is created", func() {
+		var (
+			connectionTimeout uint32
+			clientConfig      ClientConfig
+			testDatabase      string
+			client            Client
+		)
+
+		BeforeEach(func() {
+			hosts := os.Getenv("MONGO_TEST_HOSTS")
+			username := os.Getenv("MONGO_TEST_USERNAME")
+			password := os.Getenv("MONGO_TEST_PASSWORD")
+			connectionTimeoutStr := os.Getenv("MONGO_TEST_CONNECTION_TIMEOUT_MS")
+			testDatabase = os.Getenv("MONGO_TEST_DATABASE")
+
+			var err error
+			// Set Connection Timeout
+			connectionTimeoutInt, err := strconv.Atoi(connectionTimeoutStr)
+			if err != nil {
+				err = errors.Wrap(
+					err,
+					"error getting CONNECTION_TIMEOUT from env, will use 1000",
+				)
+				log.Println(err)
+				connectionTimeoutInt = 1000
+			}
+			connectionTimeout = uint32(connectionTimeoutInt)
+
+			// Client Configuration
+			clientConfig = ClientConfig{
+				Hosts:               *utils.ParseHosts(hosts),
+				Username:            username,
+				Password:            password,
+				TimeoutMilliseconds: connectionTimeout,
+			}
+		})
+
+		AfterEach(func() {
+			err := client.Disconnect()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should create a new client", func() {
+			client, err := NewClient(clientConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(client).To(BeAssignableToTypeOf(&Client{}))
+			Expect(client.client).ToNot(BeNil())
+			Expect(client.client).To(BeAssignableToTypeOf(&mgo.Client{}))
+		})
+
+		It("should return any errors that occur", func() {
+			clientConfig.Hosts = []string{"@invalid-url^@"}
+			_, err := NewClient(clientConfig)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should set the correct timeout as specified", func() {
+			clientConfig.TimeoutMilliseconds = 2976
+			client, err := NewClient(clientConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(client.timeout).To(Equal(uint32(2976)))
+		})
+
+		It("should set the default timeout if timeout is not specified", func() {
+			clientConfig.TimeoutMilliseconds = 0
+			client, err := NewClient(clientConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(client.timeout).To(Equal(uint32(1000)))
+		})
+
+		It(
+			"should not connect automatically if the NoDefaultConnect is specified",
+			func() {
+				clientConfig.NoDefaultConnect = true
+				client, err := NewClient(clientConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(client.connected).To(BeFalse())
+			},
+		)
+
+		It(
+			"should connect automatically if the NoDefaultConnect is not specified",
+			func() {
+				client, err := NewClient(clientConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(client.connected).To(BeTrue())
+			},
+		)
+
+		It("should connect to Database when Connect is called", func() {
+			clientConfig.NoDefaultConnect = true
+			client, err := NewClient(clientConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = client.Connect()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(client.connected).To(BeTrue())
+		})
+
+		It("should disconnect from Database when Disconnect is called", func() {
+			client, err := NewClient(clientConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = client.Disconnect()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(client.connected).To(BeFalse())
+		})
+
+		It("should return the Database instance when Database is requested", func() {
+			client, err := NewClient(clientConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			db := client.Database(testDatabase)
+			Expect(db).To(BeAssignableToTypeOf(&mgo.Database{}))
+			Expect(db.Name()).To(Equal(testDatabase))
+		})
+
+		It("should return the correct DriverClient", func() {
+			client, err := NewClient(clientConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			dc := client.DriverClient()
+			Expect(dc).To(BeAssignableToTypeOf(&mgo.Client{}))
+
+			expectedConnStr := fmt.Sprintf(
+				"mongodb://%s:%s@%s",
+				clientConfig.Username,
+				clientConfig.Password,
+				clientConfig.Hosts[0],
+			)
+			Expect(dc.ConnectionString()).To(Equal(expectedConnStr))
+		})
+	})
+})

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -14,8 +14,8 @@ import (
 // ConnectionConfig defines the Client to use for
 // communicating with MongoDB, and the Timeout for that client.
 type ConnectionConfig struct {
-	Client  *mgo.Client
-	Timeout uint
+	Client  *Client
+	Timeout uint32
 }
 
 // IndexColumnConfig defines configuration for

--- a/mongo/datautils.go
+++ b/mongo/datautils.go
@@ -9,7 +9,7 @@ import (
 )
 
 // newTimeoutContext creates a new WithTimeout context with specified timeout.
-func newTimeoutContext(timeout uint) (ctx.Context, ctx.CancelFunc) {
+func newTimeoutContext(timeout uint32) (ctx.Context, ctx.CancelFunc) {
 	return ctx.WithTimeout(
 		ctx.Background(),
 		time.Duration(timeout)*time.Millisecond,

--- a/mongo/datautils_test.go
+++ b/mongo/datautils_test.go
@@ -14,7 +14,7 @@ var _ = Describe("MongoUtils", func() {
 	Describe("newTimeoutContext", func() {
 		It("should return WithTimeout context with specified timeout", func() {
 			Context("deadline exceeds", func() {
-				timeout := uint(20) // Milliseconds
+				timeout := uint32(20) // Milliseconds
 				ctx, cancel := newTimeoutContext(timeout)
 				defer cancel()
 
@@ -35,7 +35,7 @@ var _ = Describe("MongoUtils", func() {
 			})
 
 			Context("deadline not does exceed", func() {
-				timeout := uint(20) // Milliseconds
+				timeout := uint32(20) // Milliseconds
 				ctx, cancel := newTimeoutContext(timeout)
 				defer cancel()
 

--- a/mongo/mongo_suite_test.go
+++ b/mongo/mongo_suite_test.go
@@ -1,21 +1,24 @@
 package mongo
 
 import (
-	"os"
+	"log"
 	"testing"
 
+	"github.com/joho/godotenv"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 )
 
-var testDatabase = "lib_test_db"
-var connStr = os.Getenv("MONGODB_TEST_CONN_STR")
-
-// Tests will use this testDatabase
-func TestCassandra(t *testing.T) {
-	if connStr == "" {
-		connStr = "mongodb://root:root@localhost:27017"
+func TestMongo(t *testing.T) {
+	err := godotenv.Load("../test.env")
+	if err != nil {
+		err = errors.Wrap(err,
+			".env file not found, env-vars will be read as set in environment",
+		)
+		log.Println(err)
 	}
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Mongo Suite")
 }

--- a/test.env
+++ b/test.env
@@ -1,0 +1,10 @@
+# Configuration for tests
+# ---
+MONGO_TEST_HOSTS=127.0.0.1:27017
+MONGO_TEST_USERNAME=root
+MONGO_TEST_PASSWORD=root
+# This database will be constantly deleted/recreated during tests.
+MONGO_TEST_DATABASE=lib_test_db
+
+MONGO_TEST_CONNECTION_TIMEOUT_MS=1000
+MONGO_TEST_RESOURCE_TIMEOUT_MS=3000


### PR DESCRIPTION
closes #10 

Using the new Client-wrapper:

```Go
config := mongo.ClientConfig{
  Hosts:               []string{"localhost:27017"},
  Username:            "root",
  Password:            "root",
  TimeoutMilliseconds: 3000,
}

// ====> MongoDB Client
client, err := mongo.NewClient(config)
if err != nil {
  log.Fatalln(err)
}
```