### PR TITLE
Implement InsertMany for collections

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:7ade2e115ef9ce096d40ea08e28744ec89cf0272713d69ef2de5b1c92faf16a7"
+  digest = "1:f446f7e9171044d853ff08a894e733cdb66538a32b6a66b2bce5de7c691897a2"
   name = "github.com/TerrexTech/go-commonutils"
   packages = ["utils"]
   pruneopts = "UT"
-  revision = "646e693606e0859a338f7c24765581d253be5e8d"
-  version = "v1.0"
+  revision = "ee7a939084fdb644ca3f925275195b170610f3e3"
+  version = "v2.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,7 +34,7 @@
 
 [[constraint]]
   name = "github.com/TerrexTech/go-commonutils"
-  version = "1.0.0"
+  version = "2.0.0"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"

--- a/examples/example.go
+++ b/examples/example.go
@@ -21,7 +21,12 @@ type item struct {
 }
 
 func main() {
-	collection, err := createCollection()
+	client, err := createClient()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	collection, err := createCollection(client)
 	if err != nil {
 		log.Fatalln(err, collection)
 	}
@@ -61,8 +66,8 @@ func main() {
 	aggregatePipeline(collection)
 }
 
-// createCollection demonstrates creating the collection and the associated database.
-func createCollection() (*mongo.Collection, error) {
+// createClient creates a MongoDB-Client.
+func createClient() (*mongo.Client, error) {
 	// Would ideally set these config-params as environment vars
 	config := mongo.ClientConfig{
 		Hosts:               []string{"localhost:27017"},
@@ -73,10 +78,12 @@ func createCollection() (*mongo.Collection, error) {
 
 	// ====> MongoDB Client
 	client, err := mongo.NewClient(config)
-	if err != nil {
-		log.Fatalln(err)
-	}
+	// Let the parent functions handle error, always -.-
+	return client, err
+}
 
+// createCollection demonstrates creating the collection and the associated database.
+func createCollection(client *mongo.Client) (*mongo.Collection, error) {
 	// ====> Collection Configuration
 	conn := &mongo.ConnectionConfig{
 		Client:  client,

--- a/mongo/collection_test.go
+++ b/mongo/collection_test.go
@@ -327,6 +327,58 @@ var _ = Describe("MongoCollection", func() {
 		})
 	})
 
+	Describe("InsertMany", func() {
+		It("should insert provided data if the data is not a pointer", func() {
+			data := []interface{}{
+				item{
+					Word:       "some-word",
+					Definition: "some-definition",
+				},
+				item{
+					Word:       "some-word2",
+					Definition: "some-definition2",
+				},
+			}
+			result, err := c.InsertMany(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(*result)).To(Equal(2))
+
+			for _, id := range *result {
+				Expect(id.InsertedID).To(BeAssignableToTypeOf(objectid.ObjectID{}))
+			}
+		})
+
+		It("should insert provided data if the data is a pointer", func() {
+			data := []interface{}{
+				&item{
+					Word:       "some-word",
+					Definition: "some-definition",
+				},
+				&item{
+					Word:       "some-word2",
+					Definition: "some-definition2",
+				},
+			}
+			result, err := c.InsertMany(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(*result)).To(Equal(2))
+
+			for _, id := range *result {
+				Expect(id.InsertedID).To(BeAssignableToTypeOf(objectid.ObjectID{}))
+			}
+		})
+
+		It("should throw error if filter-schema and collection-schema mismatch", func() {
+			data := struct {
+				Mismatch string
+			}{
+				Mismatch: "yup",
+			}
+			_, err := c.InsertOne(data)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Describe("UpdateMany", func() {
 		// Insert some test-data
 		BeforeEach(func() {

--- a/mongo/datautils.go
+++ b/mongo/datautils.go
@@ -51,3 +51,15 @@ func copyInterface(intf interface{}) interface{} {
 	}
 	return reflect.New(intfType).Interface()
 }
+
+// verifyArrayOrSliceType returns true if the passed interface{}
+// is an array or slice (can also be a pointer to an array or slice).
+func verifyArrayOrSliceType(intf interface{}) bool {
+	kind := reflect.TypeOf(intf).Kind()
+	// Deref if its a pointer
+	if kind == reflect.Ptr {
+		kind = reflect.TypeOf(intf).Elem().Kind()
+	}
+	isValid := kind == reflect.Array || kind == reflect.Slice
+	return isValid
+}

--- a/mongo/datautils_test.go
+++ b/mongo/datautils_test.go
@@ -127,4 +127,56 @@ var _ = Describe("MongoUtils", func() {
 			})
 		})
 	})
+
+	Describe("verifyArrayOrSliceType", func() {
+		Context("slice is passed", func() {
+			It("should return true", func() {
+				testSlice := []int{1, 2, 4, 5}
+				isSlice := verifyArrayOrSliceType(testSlice)
+				Expect(isSlice).To(BeTrue())
+			})
+		})
+
+		Context("pointer to slice is passed", func() {
+			It("should return true", func() {
+				testSlice := &[]int{1, 2, 4, 5}
+				isSlice := verifyArrayOrSliceType(testSlice)
+				Expect(isSlice).To(BeTrue())
+			})
+		})
+
+		Context("array is passed", func() {
+			It("should return true", func() {
+				testArray := [4]int{1, 2, 4, 5}
+				isArray := verifyArrayOrSliceType(testArray)
+				Expect(isArray).To(BeTrue())
+			})
+		})
+
+		Context("pointer to array is passed", func() {
+			It("should return true", func() {
+				testArray := &[4]int{1, 2, 4, 5}
+				isArray := verifyArrayOrSliceType(testArray)
+				Expect(isArray).To(BeTrue())
+			})
+		})
+
+		Context("non array or slice is passed", func() {
+			It("should return false", func() {
+				testInt := 4
+				isValid := verifyArrayOrSliceType(testInt)
+				Expect(isValid).To(BeFalse())
+
+				testString := "test"
+				isValid = verifyArrayOrSliceType(testString)
+				Expect(isValid).To(BeFalse())
+
+				testMap := map[string]interface{}{
+					"test": 1,
+				}
+				isValid = verifyArrayOrSliceType(testMap)
+				Expect(isValid).To(BeFalse())
+			})
+		})
+	})
 })


### PR DESCRIPTION
closes #15 

We don't use `#InsertMany` from Mongo-Go-Driver because it appears that passing in `[]interface{}` and then converting each element to `BsonDocument` causes the driver to insert data as an array within same document, instead of creating a separate document for each element.